### PR TITLE
DATADEPS cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.2.0]
+
+### Fixed
+- Remove statements that automatically allow DATADEPS downloading. Now simply catches the error and prints a message to the user. For users, remember to set `ENV["DATADEPS_ALWAYS_ACCEPT"] = true` before running the package.
+
 ## [0.1.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SemanticCaches"
 uuid = "03ba8f0e-aaaa-4626-a19b-56297996781b"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Note that we're using a tiny BERT model with a maximum chunk size of 512 tokens 
 For longer sentences, we split them in several chunks and consider their average embedding, but use it carefully! The latency can sky rocket and become worse than simply calling the original API.
 
 ## Installation
-To install SemanticCaches.jl, simply add this repository (package is not yet registered).
+To install SemanticCaches.jl, simply add the package using the Julia package manager:
 
 ```julia
-using Pkg
-Pkg.add("https://github.com/svilupp/SemanticCaches.jl")
+using Pkg;
+Pkg.activate(".")
+Pkg.add("SemanticCaches")
 ```
 
 ## Quick Start Guide
 
 ```julia
+## This line is very important to be able to download the models!!!
 ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
 using SemanticCaches
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SemanticCaches 
+# SemanticCaches.jl
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://svilupp.github.io/SemanticCaches.jl/dev/) 
 [![Build Status](https://github.com/svilupp/SemanticCaches.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/svilupp/SemanticCaches.jl/actions/workflows/CI.yml?query=branch%3Amain) 
 [![Coverage](https://codecov.io/gh/svilupp/SemanticCaches.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/svilupp/SemanticCaches.jl) 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,16 +13,19 @@ Note that we're using a tiny BERT model with a maximum chunk size of 512 tokens 
 For longer sentences, we split them in several chunks and consider their average embedding, but use it carefully! The latency can sky rocket and become worse than simply calling the original API.
 
 ## Installation
-To install SemanticCaches.jl, simply add this repository (package is not yet registered).
+
+To install SemanticCaches.jl, simply add the package using the Julia package manager:
 
 ```julia
-using Pkg
-Pkg.add("https://github.com/svilupp/SemanticCaches.jl")
+using Pkg;
+Pkg.activate(".")
+Pkg.add("SemanticCaches")
 ```
 
 ## Quick Start Guide
 
 ```julia
+## This line is very important to be able to download the models!!!
 ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
 using SemanticCaches
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,9 +2,9 @@
 CurrentModule = SemanticCaches
 ```
 
-# SemanticCaches
+# SemanticCaches.jl
 
-Documentation for [SemanticCaches](https://github.com/svilupp/SemanticCaches.jl).
+Documentation for [SemanticCaches.jl](https://github.com/svilupp/SemanticCaches.jl).
 
 SemanticCaches.jl is a very hacky implementation of a semantic cache for AI applications to save time and money with repeated requests.
 It's not particularly fast, because we're trying to prevent API calls that can take even 20 seconds.

--- a/src/SemanticCaches.jl
+++ b/src/SemanticCaches.jl
@@ -1,9 +1,5 @@
 module SemanticCaches
 
-## Cowboy mode to solve CI failures in auto-merge
-## Always set download true if not set otherwise
-get!(ENV, "DATADEPS_ALWAYS_ACCEPT", "true")
-
 using HTTP
 using LinearAlgebra
 using Dates
@@ -11,7 +7,7 @@ using Statistics: mean
 using FlashRank
 using FlashRank: EmbedderModel
 
-global EMBEDDER::Union{Nothing,EmbedderModel} = nothing
+global EMBEDDER::Union{Nothing, EmbedderModel} = nothing
 
 export SemanticCache, CachedItem, HashCache
 include("types.jl")
@@ -21,10 +17,6 @@ include("similarity_lookup.jl")
 function __init__()
     ## Initialize the embedding model
     global EMBEDDER
-    ## If we are in the CI, auto-download
-    if haskey(ENV,"CI")
-        ENV["DATADEPS_ALWAYS_ACCEPT"] = "true"
-    end
     EMBEDDER = try
         EmbedderModel(:tiny_embed)
     catch e


### PR DESCRIPTION
- Remove statements that automatically allow DATADEPS downloading. Now simply catches the error and prints a message to the user. For users, remember to set `ENV["DATADEPS_ALWAYS_ACCEPT"] = true` before running the package.